### PR TITLE
Update all dependencies

### DIFF
--- a/Cake.Baker/addins.cake
+++ b/Cake.Baker/addins.cake
@@ -1,16 +1,15 @@
-#addin nuget:?package=Cake.Codecov&version=0.3.0
-#addin nuget:?package=Cake.Coveralls&version=0.7.0
-#addin nuget:?package=Cake.Figlet&version=1.0.0
-#addin nuget:?package=Cake.Gitter&version=0.7.0
-#addin nuget:?package=Cake.Incubator&version=2.0.1
-#addin nuget:?package=Cake.MicrosoftTeams&version=0.6.0
-#addin nuget:?package=Cake.Slack&version=0.10.0
-#addin nuget:?package=Cake.Twitter&version=0.6.0
+#addin nuget:?package=Cake.Codecov&version=0.4.0
+#addin nuget:?package=Cake.Coveralls&version=0.9.0
+#addin nuget:?package=Cake.Figlet&version=1.2.0
+#addin nuget:?package=Cake.Gitter&version=0.10.0
+#addin nuget:?package=Cake.Incubator&version=3.0.0
+#addin nuget:?package=Cake.MicrosoftTeams&version=0.8.0
+#addin nuget:?package=Cake.Slack&version=0.12.0
+#addin nuget:?package=Cake.Twitter&version=0.9.0
 
-
-// #addin nuget:?package=Cake.Git&version=0.16.1
-// #addin nuget:?package=Cake.Graph&version=0.4.0
-// #addin nuget:?package=Cake.Kudu&version=0.6.0
-// #addin nuget:?package=Cake.ReSharperReports&version=0.8.0
-// #addin nuget:?package=Cake.Transifex&Version=0.4.0
-// #addin nuget:?package=Cake.Wyam&version=1.2.0
+// #addin nuget:?package=Cake.Git&version=0.19.0
+// #addin nuget:?package=Cake.Graph&version=0.7.1
+// #addin nuget:?package=Cake.Kudu&version=0.8.0
+// #addin nuget:?package=Cake.ReSharperReports&version=0.10.0
+// #addin nuget:?package=Cake.Transifex&Version=0.7.0
+// #addin nuget:?package=Cake.Wyam&version=2.0.0

--- a/Cake.Baker/projects.cake
+++ b/Cake.Baker/projects.cake
@@ -22,7 +22,7 @@ public class Projects
     {
         ICakeContext context = builder.Context;
 
-        if (context.FileExists(builder.Paths.Files.Solution))
+        if (builder.Paths.Files.Solution != null && context.FileExists(builder.Paths.Files.Solution))
         {
             var configuration = builder.Parameters.Configuration;
             var platformTarget = builder.ToolSettings.UsingBuildPlatformTarget;

--- a/Cake.Baker/tools.cake
+++ b/Cake.Baker/tools.cake
@@ -1,20 +1,19 @@
-#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0012"
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 
-private const string CodecovTool = "#tool nuget:?package=codecov&version=1.0.3";
-private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.3.4";
-private const string FixieTool = "#tool nuget:?package=Fixie&version=2.0.0";
-private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.7.0";
-private const string NUnitTool = "#tool nuget:?package=NUnit.ConsoleRunner&version=3.8.0";
+private const string CodecovTool = "#tool nuget:?package=codecov&version=1.1.0";
+private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.4.2";
+private const string FixieTool = "#tool nuget:?package=Fixie&version=2.0.2";
+private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.7.1";
+private const string NUnitTool = "#tool nuget:?package=NUnit.ConsoleRunner&version=3.9.0";
 private const string OpenCoverTool = "#tool nuget:?package=OpenCover&version=4.6.519";
-private const string ReportGeneratorTool = "#tool nuget:?package=ReportGenerator&version=3.1.2";
+private const string ReportGeneratorTool = "#tool nuget:?package=ReportGenerator&version=4.0.4";
 private const string ReportUnitTool = "#tool nuget:?package=ReportUnit&version=1.2.1";
-private const string XUnitTool = "#tool nuget:?package=xunit.runner.console&version=2.3.1";
+private const string XUnitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1";
 
-
-// private const string GitLinkTool = "#tool nuget:?package=gitlink&version=2.4.0";
-// private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.2";
-// private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";
-// private const string MSBuildExtensionPackTool = "#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.0";
-// private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.2.0";
-// private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.2.0";
-// private const string WyamTool = "#tool nuget:?package=Wyam&version=1.2.0";
+// private const string GitLinkTool = "#tool nuget:?package=gitlink&version=3.1.0";
+// private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=4.0.0";
+// private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.5.2";
+// private const string MSBuildExtensionPackTool = "#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.1";
+// private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.4.0";
+// private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.2.3";
+// private const string WyamTool = "#tool nuget:?package=Wyam&version=2.0.0";

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load nuget:https://www.myget.org/F/arkord/api/v2?package=Cake.Baker&version=0.1.0 //&prerelease
+#load nuget:https://www.myget.org/F/arkord/api/v2?package=Cake.Baker&version=0.11.0
 
 Task("PublishCakeBaker")
     .IsDependentOn("ShowInfo")

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.2" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
Note: due to the self-referencing Cake.Baker build and issues aligning with Cake 0.30.0, I had to copy the `*.cake` files from `Cake.Baker` to `tools\Cake.Baker.0.11.0\content` to get the build to work. Once the next Cake.Baker NuGet package is published, the `build.cake` should be updated to use that instead. 😉 